### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/opennx/LibUSB.cpp
+++ b/opennx/LibUSB.cpp
@@ -302,6 +302,8 @@ static bool addDeviceInfo( const USBInfo& u )
         return false;
 
     dbDeviceInfo[u.key()] = u;
+    
+    return true;
 }
 // ----------------------------------------------------------------------------
 static USBInfo findDeviceInfo( const wxString &vendorID, const wxString &deviceID )

--- a/opennx/ModuleManager.h
+++ b/opennx/ModuleManager.h
@@ -16,7 +16,6 @@ private:
     ModulesMap modules;
 
     ModuleManager(ModuleManager const&) {} //delete
-    ModuleManager& operator= (ModuleManager const&) {} //delete
 public:
 
     static ModuleManager& instance();


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.